### PR TITLE
Add Python script to retroactively update domain/IP lists

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+hosts     text eol=crlf
+*         text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+.venv/
+__pycache__
+
+hosts.bak

--- a/dnsmasq
+++ b/dnsmasq
@@ -1,14 +1,14 @@
 config domain
-				option name '3d5vic7so2.adobestats.io'
-				option ip '0.0.0.0'
+        option name '3d5vic7so2.adobestats.io'
+        option ip '0.0.0.0'
 
 config domain
-				option name 'o987771.ingest.us.sentry.io'
-				option ip '0.0.0.0'
+        option name 'o987771.ingest.us.sentry.io'
+        option ip '0.0.0.0'
 
 config domain
-				option name 'a1815.dscr.akamai.net'
-				option ip '0.0.0.0'
+        option name 'a1815.dscr.akamai.net'
+        option ip '0.0.0.0'
 
 config domain
         option name 'adobe.io'

--- a/lists.py
+++ b/lists.py
@@ -9,12 +9,20 @@ parser.add_argument("-RD", "--remove-duplicates",
 args = parser.parse_args()
 
 
-def read_stripped(file: str):
+def read_stripped(file: str, strip_lines=True):
+    """
+    This reads the file and strips out any empty and comment lines with `#`
+    """
     try:
         with open(file, "r") as f:
+            file_contents = f.readlines()
+
+            if not strip_lines:
+                return file_contents
+
             strip_comments = [l.strip()
                               if not l.startswith("#") else None
-                              for l in f.readlines()]
+                              for l in file_contents]
 
             return list(filter(None, strip_comments))
 
@@ -34,6 +42,7 @@ def dnsmasq_fmt(*domains):
 def main():
     hosts_record = read_stripped("hosts")
     dnsmasq_record = read_stripped("dnsmasq")
+    pihole_record = read_stripped("PiHole", False)
 
 
 if __name__ == "__main__":

--- a/lists.py
+++ b/lists.py
@@ -8,6 +8,12 @@ parser.add_argument("-RD", "--remove-duplicates",
 
 args = parser.parse_args()
 
+_INDENT = " "*2*2
+
+
+def whitespace_join(arr: list[str]):
+    return "\n".join(arr)
+
 
 def read_stripped(file: str, strip_lines=True):
     """
@@ -31,18 +37,44 @@ def read_stripped(file: str, strip_lines=True):
 
 
 def dnsmasq_fmt(*domains):
-    space_indent = " "*2*4
 
-    domain_list = [f"config domain\n{space_indent}option name '{domain}'\n{space_indent}option ip '0.0.0.0'\n"
+    domain_list = [f"config domain\n{_INDENT}option name '{domain}'\n{_INDENT}option ip '0.0.0.0'\n"
                    for domain in domains]
 
-    return "\n".join(domain_list)
+    return whitespace_join(domain_list)
+
+
+def check_dups(arr: list[str]):
+    deduped_set: set[str] = set()
+    duplicates: list[str] = []
+
+    for item in arr:
+        if item in deduped_set:
+            duplicates.append(item)
+        else:
+            deduped_set.add(item)
+
+    len_dups = len(duplicates)
+
+    if len_dups == 0:
+        print("There are no duplicates")
+        return arr
+
+    print("Found {} duplicate(s)\n\n{}\n".format(
+        len_dups,
+        whitespace_join([f"{_INDENT}- {d}" for d in duplicates])
+    ))
+
+    return list(deduped_set)
 
 
 def main():
     hosts_record = read_stripped("hosts")
     dnsmasq_record = read_stripped("dnsmasq")
     pihole_record = read_stripped("PiHole", False)
+
+    if args.remove_duplicates:
+        check_dups(hosts_record)
 
 
 if __name__ == "__main__":

--- a/lists.py
+++ b/lists.py
@@ -36,8 +36,7 @@ def read_stripped(file: str, strip_lines=True):
         raise e
 
 
-def dnsmasq_fmt(*domains):
-
+def dnsmasq_fmt(*domains: tuple[str]):
     domain_list = [f"config domain\n{_INDENT}option name '{domain}'\n{_INDENT}option ip '0.0.0.0'\n"
                    for domain in domains]
 
@@ -46,15 +45,15 @@ def dnsmasq_fmt(*domains):
 
 def check_dups(arr: list[str]):
     deduped_set: set[str] = set()
-    duplicates: list[str] = []
+    duplicates_list: list[str] = []
 
     for item in arr:
         if item in deduped_set:
-            duplicates.append(item)
+            duplicates_list.append(item)
         else:
             deduped_set.add(item)
 
-    len_dups = len(duplicates)
+    len_dups = len(duplicates_list)
 
     if len_dups == 0:
         print("There are no duplicates")
@@ -62,7 +61,7 @@ def check_dups(arr: list[str]):
 
     print("Found {} duplicate(s)\n\n{}\n".format(
         len_dups,
-        whitespace_join([f"{_INDENT}- {d}" for d in duplicates])
+        whitespace_join([f"{_INDENT}- {d}" for d in duplicates_list])
     ))
 
     return list(deduped_set)

--- a/lists.py
+++ b/lists.py
@@ -15,20 +15,30 @@ def whitespace_join(arr: list[str]):
     return "\n".join(arr)
 
 
-def read_stripped(file: str, strip_lines=True):
+def omit_ln(_tuple: list[tuple[int, str]]):
+    """
+    Filters out the line numbers invoked from `read_stripped`, thus only leaving the lines themselves
+    """
+    return [l for _, l in _tuple]
+
+
+def read_stripped(file: str, strip_comments=True):
     """
     This reads the file and strips out any empty and comment lines with `#`
+
+    Returns:
+        A list of tuple with line number and the line itself for identifying duplicates
     """
     try:
         with open(file, "r") as f:
-            file_contents = f.readlines()
+            file_contents = enumerate(f.readlines())
 
-            if not strip_lines:
-                return file_contents
+            if not strip_comments:
+                return [(ln, line.strip()) for ln, line in file_contents]
 
-            strip_comments = [l.strip()
-                              if not l.startswith("#") else None
-                              for l in file_contents]
+            strip_comments = [(ln, line.strip())
+                              if not (line.startswith("#") or line.strip() == "") else None
+                              for ln, line in file_contents]
 
             return list(filter(None, strip_comments))
 
@@ -43,25 +53,25 @@ def dnsmasq_fmt(*domains: tuple[str]):
     return whitespace_join(domain_list)
 
 
-def check_dups(arr: list[str]):
+def check_dups(arr: list[tuple[int, str]]):
     deduped_set: set[str] = set()
-    duplicates_list: list[str] = []
+    duplicates_list: list[tuple[int, str]] = []
 
-    for item in arr:
+    for ln, item in arr:
         if item in deduped_set:
-            duplicates_list.append(item)
+            duplicates_list.append((ln, item))
         else:
             deduped_set.add(item)
 
     len_dups = len(duplicates_list)
 
     if len_dups == 0:
-        print("There are no duplicates")
+        print("No duplicates are found")
         return arr
 
     print("Found {} duplicate(s)\n\n{}\n".format(
         len_dups,
-        whitespace_join([f"{_INDENT}- {d}" for d in duplicates_list])
+        whitespace_join([f"{_INDENT} ln: {ln} - {dl}" for ln, dl in duplicates_list])  # noqa
     ))
 
     return list(deduped_set)
@@ -73,7 +83,11 @@ def main():
     pihole_record = read_stripped("PiHole", False)
 
     if args.remove_duplicates:
+        print("In hosts:")
         check_dups(hosts_record)
+
+        print("In PiHole:")
+        check_dups(pihole_record)
 
 
 if __name__ == "__main__":

--- a/lists.py
+++ b/lists.py
@@ -1,0 +1,40 @@
+from argparse import ArgumentParser
+
+parser = ArgumentParser()
+
+parser.add_argument("-i", "--add", type=str)
+parser.add_argument("-RD", "--remove-duplicates",
+                    action="store_true", default=False)
+
+args = parser.parse_args()
+
+
+def read_stripped(file: str):
+    try:
+        with open(file, "r") as f:
+            strip_comments = [l.strip()
+                              if not l.startswith("#") else None
+                              for l in f.readlines()]
+
+            return list(filter(None, strip_comments))
+
+    except FileNotFoundError as e:
+        raise e
+
+
+def dnsmasq_fmt(*domains):
+    space_indent = " "*2*4
+
+    domain_list = [f"config domain\n{space_indent}option name '{domain}'\n{space_indent}option ip '0.0.0.0'\n"
+                   for domain in domains]
+
+    return "\n".join(domain_list)
+
+
+def main():
+    hosts_record = read_stripped("hosts")
+    dnsmasq_record = read_stripped("dnsmasq")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #37; this adds a Python file to add and sync across the `hosts`, `dnsmasq`, and the `PiHole` files, and remove any duplicates if present

## Changes

- [x] Fix indentation on `dnsmasq`
- [ ] Add a PowerShell script to add them to the `hosts` file and create a `hosts.bak` as a backup
- [x] Dedupe logic
- [ ] Sort the list in alphabetical order
- [ ] Add an issue template for users to file for new domains and possibly GitHub workflow to create a PR from the IP addresses/domains specified
- [ ] Add a workflow on every push and execute `python lists.py --remove-duplicates`
