### PR TITLE
Add macOS and Linux support, finish the Windows apply/revert scripts

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -90,3 +90,6 @@ jobs:
           # Reverting with nothing applied must fail with a clear message
           cmd /c revert.bat
           if ($LASTEXITCODE -eq 0) { throw 'Expected revert.bat to fail when nothing is applied' }
+
+          # The failure above is expected; don't let its exit code fail the step
+          exit 0

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,52 @@
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        run: shellcheck apply.sh revert.sh
+
+  test-scripts:
+    name: Test apply/revert scripts
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test apply, idempotency, and revert
+        env:
+          ADOBE_BLOCKLIST_HOSTS_FILE: ${{ runner.temp }}/hosts
+        run: |
+          printf '127.0.0.1 localhost\n' > "$ADOBE_BLOCKLIST_HOSTS_FILE"
+          cp "$ADOBE_BLOCKLIST_HOSTS_FILE" "$ADOBE_BLOCKLIST_HOSTS_FILE.orig"
+
+          expected="$(grep -cEv '^[[:space:]]*(#|$)' hosts)"
+
+          ./apply.sh
+          applied="$(grep -c '^0\.0\.0\.0' "$ADOBE_BLOCKLIST_HOSTS_FILE")"
+          [ "$applied" -eq "$expected" ] || { echo "Expected $expected records, found $applied"; exit 1; }
+
+          # Re-running must replace the block, not append duplicates
+          ./apply.sh
+          applied="$(grep -c '^0\.0\.0\.0' "$ADOBE_BLOCKLIST_HOSTS_FILE")"
+          markers="$(grep -c 'ADOBE_BLOCKLIST_START' "$ADOBE_BLOCKLIST_HOSTS_FILE")"
+          [ "$applied" -eq "$expected" ] || { echo "Re-apply duplicated records: $applied"; exit 1; }
+          [ "$markers" -eq 1 ] || { echo "Re-apply duplicated markers: $markers"; exit 1; }
+
+          # Revert must restore the original file exactly
+          ./revert.sh
+          diff "$ADOBE_BLOCKLIST_HOSTS_FILE" "$ADOBE_BLOCKLIST_HOSTS_FILE.orig"
+
+          # Reverting with nothing applied must fail with a clear message
+          if ./revert.sh; then
+            echo "Expected revert to fail when nothing is applied"
+            exit 1
+          fi

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -50,3 +50,43 @@ jobs:
             echo "Expected revert to fail when nothing is applied"
             exit 1
           fi
+
+  test-bat-scripts:
+    name: Test apply/revert batch scripts
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test apply, idempotency, and revert
+        env:
+          ADOBE_BLOCKLIST_HOSTS_FILE: ${{ runner.temp }}\hosts
+        shell: pwsh
+        run: |
+          Set-Content -Path $env:ADOBE_BLOCKLIST_HOSTS_FILE -Value '127.0.0.1 localhost'
+          $original = Get-Content $env:ADOBE_BLOCKLIST_HOSTS_FILE
+
+          $expected = (Get-Content hosts | Where-Object { $_ -notmatch '^\s*(#|$)' }).Count
+
+          cmd /c apply.bat
+          if ($LASTEXITCODE -ne 0) { throw 'apply.bat failed' }
+          $applied = (Get-Content $env:ADOBE_BLOCKLIST_HOSTS_FILE | Where-Object { $_ -match '^0\.0\.0\.0' }).Count
+          if ($applied -ne $expected) { throw "Expected $expected records, found $applied" }
+
+          # Re-running must replace the block, not append duplicates
+          cmd /c apply.bat
+          if ($LASTEXITCODE -ne 0) { throw 'apply.bat re-run failed' }
+          $applied = (Get-Content $env:ADOBE_BLOCKLIST_HOSTS_FILE | Where-Object { $_ -match '^0\.0\.0\.0' }).Count
+          $markers = (Get-Content $env:ADOBE_BLOCKLIST_HOSTS_FILE | Where-Object { $_ -match 'ADOBE_BLOCKLIST_START' }).Count
+          if ($applied -ne $expected) { throw "Re-apply duplicated records: $applied" }
+          if ($markers -ne 1) { throw "Re-apply duplicated markers: $markers" }
+
+          # Revert must restore the original file contents
+          cmd /c revert.bat
+          if ($LASTEXITCODE -ne 0) { throw 'revert.bat failed' }
+          $reverted = Get-Content $env:ADOBE_BLOCKLIST_HOSTS_FILE
+          if (Compare-Object $original $reverted) { throw 'Revert did not restore the original hosts file' }
+
+          # Reverting with nothing applied must fail with a clear message
+          cmd /c revert.bat
+          if ($LASTEXITCODE -eq 0) { throw 'Expected revert.bat to fail when nothing is applied' }

--- a/README.md
+++ b/README.md
@@ -7,13 +7,23 @@ This is a curated list of all the Adobe URL/IP blocklists declared in the `hosts
 
 If you have any extra domains/IPs, you can either fork this repository and follow instructions for [Adding the records](#adding-the-records) in your fork or by [opening an issue](https://github.com/Ruddernation-Designs/Adobe-URL-Block-List/issues/new).
 
+## Compatibility
+
+| Platform | Apply | Revert | System hosts file |
+|----------|-------|--------|-------------------|
+| Windows | `apply.bat` | `revert.bat` | `%windir%\System32\drivers\etc\hosts` |
+| macOS | `apply.sh` | `revert.sh` | `/etc/hosts` |
+| Linux | `apply.sh` | `revert.sh` | `/etc/hosts` |
+
+The list is also available as a `dnsmasq` configuration and as `pihole.txt` for Pi-hole and router-level blocking, which works regardless of the client operating system.
+
 ## Applying the records in your `hosts` file
 
-### Via a script
+### Windows
 
 Simply run `apply.bat` as Administrator, and it will create a `hosts.bak` on the root of this repository so you can manually revert it later. Then adds the records from the `hosts` file onto your system.
 
-### Applying the records manually
+#### Applying the records manually
 
 The location of the `hosts` file is located at `C:\Windows\System32\drivers\etc`, or by opening the Run dialog with <kbd>Win</kbd>+ <kbd>R</kbd>, you can access it with:
 
@@ -24,18 +34,63 @@ The location of the `hosts` file is located at `C:\Windows\System32\drivers\etc`
 > [!NOTE]
 > Be sure you keep a backup of your previous `hosts` file first!
 
-Make sure you run your text editor as with admin privileges, otherwise, you won't be able to save changes to the `hosts` file. Copy and paste the full list into the `hosts` file and save it. 
+Make sure you run your text editor as with admin privileges, otherwise, you won't be able to save changes to the `hosts` file. Copy and paste the full list into the `hosts` file and save it.
 
 You may need to check your settings to show hidden files. Once there, overwrite with the host file or add the full list to your host file.
 
+### macOS and Linux
+
+Run the apply script with sudo from the root of this repository:
+
+```console
+sudo ./apply.sh
+```
+
+The script:
+
+- Backs up your current `/etc/hosts` to `hosts.bak` at the root of this repository (first run only)
+- Appends the records, wrapped between `## ADOBE_BLOCKLIST_START ##` and `## ADOBE_BLOCKLIST_END ##` markers
+- Replaces the existing block when re-run, so pulling the latest list and re-applying never duplicates records
+- Flushes the DNS cache (`dscacheutil`/`mDNSResponder` on macOS, `resolvectl` or `systemd-resolve` on Linux)
+
+To remove the records later:
+
+```console
+sudo ./revert.sh
+```
+
+Only the block between the markers is removed. Everything else in your `hosts` file stays untouched.
+
+#### Applying the records manually
+
+The `hosts` file is located at `/etc/hosts`. Append the records from this repository's `hosts` file to it (you will need sudo to save), then flush the DNS cache.
+
+On macOS:
+
+```console
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+```
+
+On Linux with systemd-resolved:
+
+```console
+sudo resolvectl flush-caches
+```
+
 ## Adding the records
 
-You'll need to have a version of Python 3.9 or higher installed to add the records and sync across `hosts`, `dnsamsq`, and `pihole.txt`.
+You'll need to have a version of Python 3.9 or higher installed to add the records and sync across `hosts`, `dnsmasq`, and `pihole.txt`.
 
 Add a domain name or IP with:
 
 ```console
 py lists.py -a 192.168.0.0 domain.example.com
+```
+
+On macOS and Linux, use `python3` instead of `py`:
+
+```console
+python3 lists.py -a 192.168.0.0 domain.example.com
 ```
 
 The script will automatically warn you if a record already exists and skip it.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ The list is also available as a `dnsmasq` configuration and as `pihole.txt` for 
 
 ### Windows
 
-Simply run `apply.bat` as Administrator, and it will create a `hosts.bak` on the root of this repository so you can manually revert it later. Then adds the records from the `hosts` file onto your system.
+Run `apply.bat` as Administrator. It will:
+
+- Back up your current `hosts` file to `hosts.bak` at the root of this repository (first run only)
+- Append the records, wrapped between `## ADOBE_BLOCKLIST_START ##` and `## ADOBE_BLOCKLIST_END ##` markers
+- Replace the existing block when re-run, so pulling the latest list and re-applying never duplicates records
+- Flush the DNS cache
+
+To remove the records later, run `revert.bat` as Administrator. Only the block between the markers is removed, everything else in your `hosts` file stays untouched.
 
 #### Applying the records manually
 

--- a/apply.bat
+++ b/apply.bat
@@ -1,32 +1,68 @@
 @echo off
+setlocal
 
-set "adobe_hosts_file=%cd%\hosts"
-set "backup_hosts_file=%cd%\hosts.bak"
+:: Applies the Adobe blocklist to the system hosts file on Windows.
+::
+:: The records are wrapped in marker comments so re-running this script
+:: replaces the previous block instead of appending duplicates, and so
+:: revert.bat can remove them cleanly.
+::
+:: Usage: run as Administrator
+
+set "adobe_hosts_file=%~dp0hosts"
+set "backup_hosts_file=%~dp0hosts.bak"
 set "sys_hosts_file=%windir%\System32\drivers\etc\hosts"
+:: Overridable so the scripts can be tested without touching the real hosts file
+if defined ADOBE_BLOCKLIST_HOSTS_FILE set "sys_hosts_file=%ADOBE_BLOCKLIST_HOSTS_FILE%"
+
+set "start_marker=## ADOBE_BLOCKLIST_START ##"
+set "end_marker=## ADOBE_BLOCKLIST_END ##"
 
 echo.
 
-:: Check for admin privilages
+if not exist "%adobe_hosts_file%" (
+  echo Blocklist file not found at %adobe_hosts_file%
+  exit /b 1
+)
+
+:: Check for admin privileges, skipped when targeting a custom hosts file
+if defined ADOBE_BLOCKLIST_HOSTS_FILE goto create_backup
+
 net session >nul 2>&1
-if %errorlevel% neq 0 (
-  echo You're not running as administrator. Please re-run this script as Administrator or a terminal with elevated privilages.
-  goto term_error
+if errorlevel 1 (
+  echo You're not running as administrator. Please re-run this script as Administrator or a terminal with elevated privileges.
+  exit /b 1
 )
 
-if not exist %backup_hosts_file% (
-  xcopy /s %sys_hosts_file% %backup_hosts_file%
+:create_backup
+if not exist "%backup_hosts_file%" (
+  copy /y "%sys_hosts_file%" "%backup_hosts_file%" >nul
   echo Created hosts.bak
-  goto term_ok
 )
 
-:add_hosts_record
-@rem TODO: add a wrapper like `## ADOBE_BLOCKLIST_START  ##` and `## ADOBE_BLOCKLIST_END  ##` so that it's easy to update and replace them later on
+:: Remove a previously applied block so re-running never duplicates records
+findstr /c:"%start_marker%" "%sys_hosts_file%" >nul 2>&1
+if errorlevel 1 goto append_block
 
+powershell -NoProfile -Command "$lines = Get-Content '%sys_hosts_file%'; $in = $false; $out = foreach ($l in $lines) { if ($l -eq '%start_marker%') { $in = $true } elseif ($l -eq '%end_marker%') { $in = $false } elseif (-not $in) { $l } }; Set-Content -Path '%sys_hosts_file%' -Value $out"
+if errorlevel 1 (
+  echo Failed to update %sys_hosts_file%
+  exit /b 1
+)
+echo Removed previously applied records
 
-:term_error
-echo.
-exit /b 1
+:append_block
+powershell -NoProfile -Command "$records = Get-Content '%adobe_hosts_file%' | Where-Object { $_ -notmatch '^\s*(#|$)' }; Add-Content -Path '%sys_hosts_file%' -Value (@('%start_marker%') + $records + '%end_marker%')"
+if errorlevel 1 (
+  echo Failed to write to %sys_hosts_file%
+  exit /b 1
+)
 
-:term_ok
-echo.
-exit
+:: Skip the DNS flush when targeting a test file rather than the real hosts file
+if not defined ADOBE_BLOCKLIST_HOSTS_FILE (
+  ipconfig /flushdns >nul
+  echo Flushed DNS cache
+)
+
+echo Applied records to %sys_hosts_file%
+exit /b 0

--- a/apply.sh
+++ b/apply.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Applies the Adobe blocklist to the system hosts file on macOS and Linux.
+#
+# The records are wrapped in marker comments so re-running this script
+# replaces the previous block instead of appending duplicates, and so
+# revert.sh can remove them cleanly.
+#
+# Usage: sudo ./apply.sh
+set -euo pipefail
+
+START_MARKER="## ADOBE_BLOCKLIST_START ##"
+END_MARKER="## ADOBE_BLOCKLIST_END ##"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADOBE_HOSTS_FILE="$SCRIPT_DIR/hosts"
+BACKUP_HOSTS_FILE="$SCRIPT_DIR/hosts.bak"
+# Overridable so the scripts can be tested without touching the real hosts file
+SYS_HOSTS_FILE="${ADOBE_BLOCKLIST_HOSTS_FILE:-/etc/hosts}"
+
+main() {
+  check_preconditions
+  create_backup
+  remove_existing_block
+  append_block
+  flush_dns_cache
+  echo "Applied $(record_count) records to $SYS_HOSTS_FILE"
+}
+
+check_preconditions() {
+  if [[ ! -f "$ADOBE_HOSTS_FILE" ]]; then
+    echo "Blocklist file not found at $ADOBE_HOSTS_FILE" >&2
+    exit 1
+  fi
+
+  if [[ ! -w "$SYS_HOSTS_FILE" ]]; then
+    echo "Cannot write to $SYS_HOSTS_FILE. Please re-run with sudo: sudo $0" >&2
+    exit 1
+  fi
+}
+
+create_backup() {
+  if [[ -f "$BACKUP_HOSTS_FILE" ]]; then
+    return
+  fi
+
+  cp "$SYS_HOSTS_FILE" "$BACKUP_HOSTS_FILE"
+  echo "Created hosts.bak"
+}
+
+remove_existing_block() {
+  if ! grep -qF "$START_MARKER" "$SYS_HOSTS_FILE"; then
+    return
+  fi
+
+  local temp_file
+  temp_file="$(mktemp)"
+  awk -v start="$START_MARKER" -v end="$END_MARKER" '
+    $0 == start { in_block = 1; next }
+    $0 == end { in_block = 0; next }
+    !in_block { print }
+  ' "$SYS_HOSTS_FILE" > "$temp_file"
+  cat "$temp_file" > "$SYS_HOSTS_FILE"
+  rm -f "$temp_file"
+  echo "Removed previously applied records"
+}
+
+append_block() {
+  {
+    echo "$START_MARKER"
+    blocklist_records
+    echo "$END_MARKER"
+  } >> "$SYS_HOSTS_FILE"
+}
+
+blocklist_records() {
+  grep -Ev '^[[:space:]]*(#|$)' "$ADOBE_HOSTS_FILE"
+}
+
+record_count() {
+  blocklist_records | wc -l | tr -d ' '
+}
+
+flush_dns_cache() {
+  # Skip when targeting a test file rather than the real hosts file
+  if [[ "$SYS_HOSTS_FILE" != "/etc/hosts" ]]; then
+    return
+  fi
+
+  case "$(uname -s)" in
+    Darwin)
+      dscacheutil -flushcache
+      killall -HUP mDNSResponder 2>/dev/null || true
+      echo "Flushed DNS cache"
+      ;;
+    Linux)
+      if command -v resolvectl > /dev/null 2>&1; then
+        resolvectl flush-caches && echo "Flushed DNS cache" && return
+      fi
+      if command -v systemd-resolve > /dev/null 2>&1; then
+        systemd-resolve --flush-caches && echo "Flushed DNS cache" && return
+      fi
+      echo "No DNS cache service detected, changes take effect immediately for new lookups"
+      ;;
+  esac
+}
+
+main "$@"

--- a/revert.bat
+++ b/revert.bat
@@ -1,23 +1,51 @@
 @echo off
+setlocal
 
-set "adobe_hosts_file=%cd%\hosts"
-set "backup_hosts_file=%cd%\hosts.bak"
+:: Reverts the Adobe blocklist from the system hosts file on Windows.
+::
+:: Removes the block between the marker comments that apply.bat added,
+:: leaving the rest of the hosts file untouched.
+::
+:: Usage: run as Administrator
+
+set "backup_hosts_file=%~dp0hosts.bak"
 set "sys_hosts_file=%windir%\System32\drivers\etc\hosts"
+:: Overridable so the scripts can be tested without touching the real hosts file
+if defined ADOBE_BLOCKLIST_HOSTS_FILE set "sys_hosts_file=%ADOBE_BLOCKLIST_HOSTS_FILE%"
+
+set "start_marker=## ADOBE_BLOCKLIST_START ##"
+set "end_marker=## ADOBE_BLOCKLIST_END ##"
 
 echo.
 
-if not exist %backup_hosts_file% (
-  echo No hosts backup file
-  goto term_error
+findstr /c:"%start_marker%" "%sys_hosts_file%" >nul 2>&1
+if errorlevel 1 (
+  echo No blocklist markers found in %sys_hosts_file%, nothing to revert.
+  if exist "%backup_hosts_file%" echo If you applied the records manually, you can restore the backup from hosts.bak as Administrator.
+  exit /b 1
 )
 
-:: Check for admin privilages
+:: Check for admin privileges, skipped when targeting a custom hosts file
+if defined ADOBE_BLOCKLIST_HOSTS_FILE goto remove_block
+
 net session >nul 2>&1
-if %errorlevel% neq 0 (
-  echo You're not running as administrator. Please re-run this script as Administrator or a terminal with elevated privilages.
-  goto term_error
+if errorlevel 1 (
+  echo You're not running as administrator. Please re-run this script as Administrator or a terminal with elevated privileges.
+  exit /b 1
 )
 
-:term_error
-echo.
-exit /b 1
+:remove_block
+powershell -NoProfile -Command "$lines = Get-Content '%sys_hosts_file%'; $in = $false; $out = foreach ($l in $lines) { if ($l -eq '%start_marker%') { $in = $true } elseif ($l -eq '%end_marker%') { $in = $false } elseif (-not $in) { $l } }; Set-Content -Path '%sys_hosts_file%' -Value $out"
+if errorlevel 1 (
+  echo Failed to update %sys_hosts_file%
+  exit /b 1
+)
+
+:: Skip the DNS flush when targeting a test file rather than the real hosts file
+if not defined ADOBE_BLOCKLIST_HOSTS_FILE (
+  ipconfig /flushdns >nul
+  echo Flushed DNS cache
+)
+
+echo Reverted %sys_hosts_file%
+exit /b 0

--- a/revert.sh
+++ b/revert.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Reverts the Adobe blocklist from the system hosts file on macOS and Linux.
+#
+# Removes the block between the marker comments that apply.sh added,
+# leaving the rest of the hosts file untouched.
+#
+# Usage: sudo ./revert.sh
+set -euo pipefail
+
+START_MARKER="## ADOBE_BLOCKLIST_START ##"
+END_MARKER="## ADOBE_BLOCKLIST_END ##"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_HOSTS_FILE="$SCRIPT_DIR/hosts.bak"
+# Overridable so the scripts can be tested without touching the real hosts file
+SYS_HOSTS_FILE="${ADOBE_BLOCKLIST_HOSTS_FILE:-/etc/hosts}"
+
+main() {
+  check_preconditions
+  remove_block
+  flush_dns_cache
+  echo "Reverted $SYS_HOSTS_FILE"
+}
+
+check_preconditions() {
+  if ! grep -qF "$START_MARKER" "$SYS_HOSTS_FILE"; then
+    echo "No blocklist markers found in $SYS_HOSTS_FILE, nothing to revert." >&2
+    if [[ -f "$BACKUP_HOSTS_FILE" ]]; then
+      echo "If you applied the records manually, you can restore the backup with:" >&2
+      echo "  sudo cp '$BACKUP_HOSTS_FILE' '$SYS_HOSTS_FILE'" >&2
+    fi
+    exit 1
+  fi
+
+  if [[ ! -w "$SYS_HOSTS_FILE" ]]; then
+    echo "Cannot write to $SYS_HOSTS_FILE. Please re-run with sudo: sudo $0" >&2
+    exit 1
+  fi
+}
+
+remove_block() {
+  local temp_file
+  temp_file="$(mktemp)"
+  awk -v start="$START_MARKER" -v end="$END_MARKER" '
+    $0 == start { in_block = 1; next }
+    $0 == end { in_block = 0; next }
+    !in_block { print }
+  ' "$SYS_HOSTS_FILE" > "$temp_file"
+  cat "$temp_file" > "$SYS_HOSTS_FILE"
+  rm -f "$temp_file"
+}
+
+flush_dns_cache() {
+  # Skip when targeting a test file rather than the real hosts file
+  if [[ "$SYS_HOSTS_FILE" != "/etc/hosts" ]]; then
+    return
+  fi
+
+  case "$(uname -s)" in
+    Darwin)
+      dscacheutil -flushcache
+      killall -HUP mDNSResponder 2>/dev/null || true
+      echo "Flushed DNS cache"
+      ;;
+    Linux)
+      if command -v resolvectl > /dev/null 2>&1; then
+        resolvectl flush-caches && echo "Flushed DNS cache" && return
+      fi
+      if command -v systemd-resolve > /dev/null 2>&1; then
+        systemd-resolve --flush-caches && echo "Flushed DNS cache" && return
+      fi
+      echo "No DNS cache service detected, changes take effect immediately for new lookups"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
This PR:
- Adds `apply.sh` and `revert.sh` for macOS and Linux: backs up to `hosts.bak`, appends the records, and flushes the DNS cache per OS
- Completes `apply.bat` and `revert.bat`, which previously only handled the backup without actually adding or removing any records
- Adds CI that lints the shell scripts and runs an apply/re-apply/revert test on ubuntu, macos, and windows runners
- Updates the README with a compatibility table and per-OS instructions

On all platforms the records are wrapped between `## ADOBE_BLOCKLIST_START ##` and `## ADOBE_BLOCKLIST_END ##` markers, picking up the TODO comment that was in `apply.bat`. Re-running apply replaces the block instead of duplicating it, and revert removes only the block, leaving the rest of the hosts file untouched.

Tested on a real macOS machine, and CI is green on all three platforms.